### PR TITLE
fix: week numbering when the sunday is the first day of week

### DIFF
--- a/src/comps/CalendarView.jsx
+++ b/src/comps/CalendarView.jsx
@@ -158,9 +158,6 @@ export default function CalendarView({
           const dayData = data.get(d.getTime())
           const isFirstWeekDay = i % 7 === 0
 
-          // ISO instead of local week number to avoid inconsistency of week number and year
-          const isoWeek = format(d, "'w'I")
-
           return (
             <div class="kef-days-day">
               {isFirstWeekDay && (
@@ -170,7 +167,7 @@ export default function CalendarView({
                     !!onGotoWeek && "kef-days-clickable",
                   )}
                   onClick={!!onGotoWeek && ((e) => onWeekClick(e, d))}
-                >{isoWeek}</div>
+                >{format(d, "'w'w")}</div>
               )}
               <div
                 class={cls(

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -91,6 +91,14 @@ async function main() {
       description: t("Characters inside single quotes '...' will be left intact. Use `ww` pattern instead of `w` to add leading zero for week numbers. Leave empty to disable week pages. (default: `yyyy-'W'w`)"),
     },
     {
+      key: "firstWeekContainsDate",
+      type: "number",
+      default: 0,
+      description: t(
+        "The first week of the year must contain the specified date. Consult your local standard. Use 0 to fallback to ISO 8601 rule: first Thursday should be in the first week.",
+      ),
+    },
+    {
       key: "displayScheduledAndDeadline",
       type: "boolean",
       default: true,
@@ -776,13 +784,18 @@ async function refreshConfigs() {
   locale = logseqLocalesMap[configs.preferredLanguage] || locale_EnUS
   preferredDateFormat = logseq.settings?.dateFormat?.trim() || configs.preferredDateFormat
   weekFormat = logseq.settings?.weekPageFormat?.trim()
+
+  let firstWeekContainsDate = logseq.settings?.firstWeekContainsDate
+  if (firstWeekContainsDate == 0)
+    firstWeekContainsDate = (
+      weekStart === 0 ? 3 :  (
+      weekStart === 1 ? 4 : 2)
+    )  // the goal is to treat week with the first Thursday as first week (ISO 8601)
+
   setDefaultOptions({
     locale: locale,
     weekStartsOn: weekStart,
-    firstWeekContainsDate: (
-      weekStart === 0 ? 3 :  (
-      weekStart === 1 ? 4 : 2)
-    ),  // the goal is to treat week with the first Thursday as first week
+    firstWeekContainsDate,
   })
 }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -785,7 +785,7 @@ async function refreshConfigs() {
   preferredDateFormat = logseq.settings?.dateFormat?.trim() || configs.preferredDateFormat
   weekFormat = logseq.settings?.weekPageFormat?.trim()
 
-  let firstWeekContainsDate = logseq.settings?.firstWeekContainsDate
+  let firstWeekContainsDate = logseq.settings?.firstWeekContainsDate ?? 0
   if (firstWeekContainsDate == 0)
     firstWeekContainsDate = (
       weekStart === 0 ? 3 :  (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -93,9 +93,9 @@ async function main() {
     {
       key: "firstWeekContainsDate",
       type: "number",
-      default: 0,
+      default: locale === locale_ZhCN ? 4 : 1,
       description: t(
-        "The first week of the year must contain the specified date. Consult your local standard. Use 0 to fallback to ISO 8601 rule: first Thursday should be in the first week.",
+        "The first week of the year must contain the specified date. Consult your local standard. To use ISO 8601 rule (first Thursday should be in the first week): set it to 4 if your week starts with Mon, 3 if it starts with Sun and 2 if it starts with Sat.",
       ),
     },
     {
@@ -784,18 +784,10 @@ async function refreshConfigs() {
   locale = logseqLocalesMap[configs.preferredLanguage] || locale_EnUS
   preferredDateFormat = logseq.settings?.dateFormat?.trim() || configs.preferredDateFormat
   weekFormat = logseq.settings?.weekPageFormat?.trim()
-
-  let firstWeekContainsDate = logseq.settings?.firstWeekContainsDate ?? 0
-  if (firstWeekContainsDate == 0)
-    firstWeekContainsDate = (
-      weekStart === 0 ? 3 :  (
-      weekStart === 1 ? 4 : 2)
-    )  // the goal is to treat week with the first Thursday as first week (ISO 8601)
-
   setDefaultOptions({
     locale: locale,
     weekStartsOn: weekStart,
-    firstWeekContainsDate,
+    firstWeekContainsDate: logseq.settings?.firstWeekContainsDate ?? 1,
   })
 }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -85,18 +85,10 @@ async function main() {
       description: t("Leave this empty to use Logseq's date format."),
     },
     {
-      key: "weekFormat",
+      key: "weekPageFormat",
       type: "string",
-      default: "yyyy-'W'I",
-      description: t("Characters inside single quotes '...' will be left intact. Use `II` pattern instead of `I` to add leading zero for week numbers. Leave empty to disable week pages. (default: `yyyy-'W'I`)"),
-    },
-    {
-      key: "firstWeekContainsDate",
-      type: "number",
-      default: locale === locale_ZhCN ? 4 : 1,
-      description: t(
-        "The first week of the year must contain the specified date. Consult your local standard.",
-      ),
+      default: "yyyy-'W'w",
+      description: t("Characters inside single quotes '...' will be left intact. Use `ww` pattern instead of `w` to add leading zero for week numbers. Leave empty to disable week pages. (default: `yyyy-'W'w`)"),
     },
     {
       key: "displayScheduledAndDeadline",
@@ -783,11 +775,14 @@ async function refreshConfigs() {
   weekStart = (+(configs.preferredStartOfWeek ?? 6) + 1) % 7
   locale = logseqLocalesMap[configs.preferredLanguage] || locale_EnUS
   preferredDateFormat = logseq.settings?.dateFormat?.trim() || configs.preferredDateFormat
-  weekFormat = logseq.settings?.weekFormat?.trim()
+  weekFormat = logseq.settings?.weekPageFormat?.trim()
   setDefaultOptions({
     locale: locale,
     weekStartsOn: weekStart,
-    firstWeekContainsDate: logseq.settings?.firstWeekContainsDate ?? 1,
+    firstWeekContainsDate: (
+      weekStart === 0 ? 3 :  (
+      weekStart === 1 ? 4 : 2)
+    ),  // the goal is to treat week with the first Thursday as first week
   })
 }
 

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -1,6 +1,7 @@
 {
   "Leave this empty to use Logseq's date format.": "使用Logseq日期格式这里请留空白。",
-  "The first week of the year must contain the specified date. Consult your local standard.": "一年的第一周必须要包含指定的日期。用来决定一年第一周的起始。",
+  "Characters inside single quotes '...' will be left intact. Use `ww` pattern instead of `w` to add leading zero for week numbers. Leave empty to disable week pages. (default: `yyyy-'W'w`)": "Characters inside single quotes '...' will be left intact. Use `ww` pattern instead of `w` to add leading zero for week numbers. Leave empty to disable week pages. (default: `yyyy-'W'w`)",
+  "The first week of the year must contain the specified date. Consult your local standard. Use 0 to fallback to ISO 8601 rule: first Thursday should be in the first week.": "一年的第一周必须要包含指定的日期。用来决定一年第一周的起始。",
   "Name of the property containing a date as value.": "一个值为日期的属性的名字。",
   "Highlight color.": "高亮颜色。",
   "Repeat interval in days (d), weeks (w), months (m) or years (y), e.g, 2w. Leave it empty if not repeated.": "以天（d）、周（w）、月（m）或年（y）计算的重复间隔，例如 2w。如果没有重复请留空。",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -1,7 +1,7 @@
 {
   "Leave this empty to use Logseq's date format.": "使用Logseq日期格式这里请留空白。",
   "Characters inside single quotes '...' will be left intact. Use `ww` pattern instead of `w` to add leading zero for week numbers. Leave empty to disable week pages. (default: `yyyy-'W'w`)": "Characters inside single quotes '...' will be left intact. Use `ww` pattern instead of `w` to add leading zero for week numbers. Leave empty to disable week pages. (default: `yyyy-'W'w`)",
-  "The first week of the year must contain the specified date. Consult your local standard. Use 0 to fallback to ISO 8601 rule: first Thursday should be in the first week.": "一年的第一周必须要包含指定的日期。用来决定一年第一周的起始。",
+  "The first week of the year must contain the specified date. Consult your local standard. To use ISO 8601 rule (first Thursday should be in the first week): set it to 4 if your week starts with Mon, 3 if it starts with Sun and 2 if it starts with Sat.": "一年的第一周必须要包含指定的日期。用来决定一年第一周的起始。",
   "Name of the property containing a date as value.": "一个值为日期的属性的名字。",
   "Highlight color.": "高亮颜色。",
   "Repeat interval in days (d), weeks (w), months (m) or years (y), e.g, 2w. Leave it empty if not repeated.": "以天（d）、周（w）、月（m）或年（y）计算的重复间隔，例如 2w。如果没有重复请留空。",


### PR DESCRIPTION
## There is the bug with ISO week numbers, when the Sunday is the first day of week
> The ISO 8601 rule is: The first week of the year is the week containing the first Thursday

But when using `I` as ISO week format (from [docs](https://date-fns.org/v3.6.0/docs/format#)), there is an issue:
<img width="329" alt="CleanShot 2024-06-15 at 22 14 34@2x" src="https://github.com/sethyuan/logseq-plugin-days/assets/1984175/b7ceee5d-c8a0-49fa-a147-df500b4fd853">


I don't know whether this is a bug or I'm missing something, but to fix this, I've switched to local week numbering with `w` formating **AND** make the `firstWeekContainsDate` to be dependant from `weekStartsOn` to emulate ISO week numbering system.

Also note, that `firstWeekContainsDate` setting is redundant, as we always use ISO week numbering.